### PR TITLE
autopid: bound header_length to prevent stack overflow in parse_elm32…

### DIFF
--- a/components/autopid/autopid.c
+++ b/components/autopid/autopid.c
@@ -2711,6 +2711,9 @@ void parse_elm327_response(char *buffer, response_t *response)
         if (data_start != NULL)
         {
             int header_length = data_start - frame;
+            if (header_length > 8) {
+                header_length = 8;
+            }
             char header_str[9] = {0};
             strncpy(header_str, frame, header_length);
             uint32_t current_header = strtoul(header_str, NULL, 16);


### PR DESCRIPTION
Problem:

parse_elm327_response() copies CAN header text into a fixed 9-byte buffer (header_str) using strncpy, but the copy length (header_length) is calculated directly from frame content with no upper bound check. A header longer than expected overflows the buffer — stack corruption.

Fix: 

Clamp header_length to a max of 8 before the copy, so it can never exceed the buffer size.

Tested:

Verified with an ASan fuzzing harness using the actual function body — vulnerable version flags/crashes on oversized input, patched version doesn't, same inputs both times. 

Also flashed to a WiCAN Pro (ESP32-S3) on IDF v5.5.4 and bench-tested: clean boot, AutoPID polling a Kia EV3 with normal MQTT data flow, zero unexpected resets in /restart_tracker/history after testing.