### PR TITLE
Skip boot PID-polling window on wake-from-sleep (prevents sleep/wake oscillation)

### DIFF
--- a/components/autopid/autopid_pause.c
+++ b/components/autopid/autopid_pause.c
@@ -86,6 +86,10 @@ bool autopid_pause_is_boot_pid_polling_keep_alive_active(const autopid_config_t 
         return false;
     }
 
+    int64_t uptime_us = esp_timer_get_time();
+    int64_t keep_alive_us = (int64_t)config->boot_pid_polling_keep_alive_seconds * 1000000LL;
+    bool within_boot_threshold = uptime_us < keep_alive_us;
+
     /* A wake from sleep is implemented as a full software reboot
      * (see sleep_mode.c, RESTART_TRACKER_PLANNED_REASON_POWER_WAKE),
      * which resets the uptime timer. Without this guard the boot
@@ -95,18 +99,20 @@ bool autopid_pause_is_boot_pid_polling_keep_alive_active(const autopid_config_t 
      * oscillation. Skip the boot window for wake-from-sleep reboots;
      * the voltage-rise and motion triggers remain the intended resume
      * paths after sleep. If the tracker has no valid record, fall
-     * through to the existing behavior. */
-    restart_tracker_record_t latest_record;
-    if (restart_tracker_get_latest_record(&latest_record) == ESP_OK &&
-        latest_record.was_planned &&
-        latest_record.planned_reason == RESTART_TRACKER_PLANNED_REASON_POWER_WAKE)
+     * through to the existing behavior. Only checked when we're still
+     * inside the boot window, to avoid the extra call once it's expired. */
+    if (within_boot_threshold)
     {
-        return false;
+        restart_tracker_record_t latest_record;
+        if (restart_tracker_get_latest_record(&latest_record) == ESP_OK &&
+            latest_record.was_planned &&
+            latest_record.planned_reason == RESTART_TRACKER_PLANNED_REASON_POWER_WAKE)
+        {
+            return false;
+        }
     }
 
-    int64_t uptime_us = esp_timer_get_time();
-    int64_t keep_alive_us = (int64_t)config->boot_pid_polling_keep_alive_seconds * 1000000LL;
-    return uptime_us < keep_alive_us;
+    return within_boot_threshold;
 }
 
 static uint32_t voltage_rise_time_seconds_or_default(uint32_t rise_time_seconds)

--- a/components/autopid/autopid_pause.c
+++ b/components/autopid/autopid_pause.c
@@ -25,6 +25,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "imu.h"
+#include "restart_tracker.h"
 #include "sleep_mode.h"
 #include "wc_timer.h"
 
@@ -81,6 +82,24 @@ static bool pid_override_mode(const autopid_config_t *config)
 bool autopid_pause_is_boot_pid_polling_keep_alive_active(const autopid_config_t *config)
 {
     if (!config || config->boot_pid_polling_keep_alive_seconds == 0)
+    {
+        return false;
+    }
+
+    /* A wake from sleep is implemented as a full software reboot
+     * (see sleep_mode.c, RESTART_TRACKER_PLANNED_REASON_POWER_WAKE),
+     * which resets the uptime timer. Without this guard the boot
+     * keep-alive window re-opens on every wake, so with the battery
+     * near the sleep threshold the polling load can pull the voltage
+     * back under it, causing a poll -> sag -> sleep -> wake -> poll
+     * oscillation. Skip the boot window for wake-from-sleep reboots;
+     * the voltage-rise and motion triggers remain the intended resume
+     * paths after sleep. If the tracker has no valid record, fall
+     * through to the existing behavior. */
+    restart_tracker_record_t latest_record;
+    if (restart_tracker_get_latest_record(&latest_record) == ESP_OK &&
+        latest_record.was_planned &&
+        latest_record.planned_reason == RESTART_TRACKER_PLANNED_REASON_POWER_WAKE)
     {
         return false;
     }


### PR DESCRIPTION
## Problem
The boot-trigger PID-polling feature ("Override poll on bootup") is meant to poll briefly right after a genuine power-on, even if voltage is below the configured pause threshold. But a wake-from-sleep is implemented as a full software reboot (restart_tracker_restart(..., RESTART_TRACKER_PLANNED_REASON_POWER_WAKE, ...) in sleep_mode.c), which resets the uptime timer — so the boot window re-opens on every wake, not just genuine boots.
With the car parked, unplugged, and 12V voltage hovering near the sleep threshold, this creates a sustained oscillation: wake → forced boot-window polling load → voltage sags back under the sleep threshold → sleep → load gone, voltage recovers → wake again → repeat. Originally flagged by @amwalters as a remaining issue on #28.

## Fix
autopid_pause_is_boot_pid_polling_keep_alive_active() now checks the restart tracker's latest record before opening the boot window. If the most recent reboot was a wake-from-sleep (RESTART_TRACKER_PLANNED_REASON_POWER_WAKE), the boot window is skipped — voltage-rise and motion triggers remain the intended way to resume polling after sleep. Any other reboot reason (power-on, user request, OTA, config-apply, internal-recovery) behaves exactly as before. If the tracker call fails for any reason, it falls back to today's behavior, so the change can't regress the existing feature.
Single file changed: components/autopid/autopid_pause.c (+19/-0).

## Testing
Unit-tested the exact patched function against 11 scenarios (config disabled, null config, genuine power-on, user/OTA/internal-recovery reboots, tracker errors, and wake-from-sleep both early and late in the window) — all pass. Re-ran the same suite against the pre-patch code as a control; it fails exactly the wake-from-sleep case, confirming the test isolates the real bug.
Confirmed on-device: forced a real sleep→wake cycle. /restart_tracker/history shows the resulting boot correctly tagged planned_reason: power_wake, source: sleep_mode, confirming the tracker records wakes exactly as the fix assumes.

Clean build, flashed via web OTA, verified normal boot/AutoPID/MQTT operation unaffected.

Edge case worth noting: RESTART_TRACKER_PLANNED_REASON_INTERNAL_RECOVERY reboots still get the boot window under this fix (only POWER_WAKE is excluded) — intentional, since a recovery reboot isn't part of the sleep-oscillation loop, but flagging it in case it should be treated differently.